### PR TITLE
Fix for Magento 2.4.6+ and Hyvae Template, improve compatibility with Cloudflare-protected shops

### DIFF
--- a/Console/Command/AbstractLitemageCommand.php
+++ b/Console/Command/AbstractLitemageCommand.php
@@ -81,6 +81,7 @@ abstract class AbstractLitemageCommand extends Command
 				'reason' => 'cli command: ' . $this->getName()];
 		$this->eventManager->dispatch('litemage_cli_purge', $param);
         $output->writeln($this->getDisplayMessage());
+        return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
 	}
 
 	protected function getInputList(InputInterface $input)

--- a/Console/Command/LitemageCliFlush.php
+++ b/Console/Command/LitemageCliFlush.php
@@ -84,6 +84,7 @@ class LitemageCliFlush extends Command
 				'Invalid action input, allowed values: status, enable, disable');
         }
         $output->writeln($mesg);
+        return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
 	}
 
     private function getCurrentStatus($allowed)

--- a/Controller/Cli/Purge.php
+++ b/Controller/Cli/Purge.php
@@ -6,8 +6,7 @@
  * @copyright  Copyright (c) LiteSpeed Technologies, Inc. All rights reserved. (https://www.litespeedtech.com)
  * @license     https://opensource.org/licenses/GPL-3.0
  */
-
-namespace Litespeed\Litemage\Controller\Shell;
+namespace Litespeed\Litemage\Controller\Cli;
 
 class Purge extends \Magento\Framework\App\Action\Action
 {
@@ -81,7 +80,7 @@ class Purge extends \Magento\Framework\App\Action\Action
         $req = $this->getRequest();
         $secret = $req->getParam('secret');
 
-        if (strlen($secret) != 32) {
+        if (strlen((string)$secret) != 32) {
             return 'Invalid request';
         }
         $file = dirname(dirname(dirname(__FILE__))) . '/Observer/FlushCacheByCli.php';
@@ -113,7 +112,7 @@ class Purge extends \Magento\Framework\App\Action\Action
         $resp = $this->getResponse();
         $resp->setHttpResponseCode(500);
         $resp->setBody($errorMesg);
-        $this->helper->debugLog('litemage/shell/purge ErrorExit: ' . $errorMesg);
+        $this->helper->debugLog('litemage/cli/purge ErrorExit: ' . $errorMesg);
     }
 
 }

--- a/Controller/Cli/Purge.php
+++ b/Controller/Cli/Purge.php
@@ -74,22 +74,22 @@ class Purge extends \Magento\Framework\App\Action\Action
             return 'Abort: LiteMage is not enabled';
         }
         if ($this->httpHeader->getHttpUserAgent() !== 'litemage_walker') {
-            return 'Access denied';
+            return 'Access denied (User-Agent mismatch): ' . $this->httpHeader->getHttpUserAgent();
         }
 
         $req = $this->getRequest();
         $secret = $req->getParam('secret');
 
         if (strlen((string)$secret) != 32) {
-            return 'Invalid request';
+            return 'Invalid request: secret length is ' . strlen((string)$secret);
         }
         $file = dirname(dirname(dirname(__FILE__))) . '/Observer/FlushCacheByCli.php';
-        $stat = stat($file);
-        $stat[] = date('l jS F Y h');
-        $secret1 = md5(print_r($stat, true));
+        $stat_str = filemtime($file) . filesize($file);
+        $secret1 = md5($stat_str . gmdate('Y-m-d-H'));
+        $secret2 = md5($stat_str . gmdate('Y-m-d-H', time() - 3600));
 
-        if ($secret != $secret1) {
-            return 'Invalid token';
+        if ($secret != $secret1 && $secret != $secret2) {
+            return 'Invalid token (Timezone/Stat mismatch)';
         }
 
         $this->_tags = [];

--- a/Model/CacheControl.php
+++ b/Model/CacheControl.php
@@ -338,7 +338,7 @@ class CacheControl
 			}
         }
         
-        if (( $responsecode == 200 || $responsecode == 404) && ($this->_isCacheable > 0)
+        if (( $responsecode == 200 || $responsecode == 201 || $responsecode == 404) && ($this->_isCacheable > 0)
         ) {
             // cacheable
             $lstags = $this->setCacheTagHeader($response);

--- a/Observer/FlushCacheByCli.php
+++ b/Observer/FlushCacheByCli.php
@@ -66,7 +66,7 @@ class FlushCacheByCli implements \Magento\Framework\Event\ObserverInterface
      */
     function __destruct()
     {
-        $this->sendPurgeRequest();
+        $this->sendPurgeRequest(true);
     }
     
 	/**
@@ -89,15 +89,16 @@ class FlushCacheByCli implements \Magento\Framework\Event\ObserverInterface
         // remaining will be handled by destructor
 	}
     
-    private function sendPurgeRequest()
+    private function sendPurgeRequest($force = false)
     {
-        while ($this->cachePurge->getPurgeTagsCount() >= self::BATCH_SIZE) {
-            $tags = $this->cachePurge->grabPurgeTags(self::BATCH_SIZE);
-    		$list = array_chunk($tags, self::BATCH_SIZE); // split to avoid url too long
-            foreach ($list as $l) {
-                $this->_shellPurge(['tags' => implode(',', $l)]);
+        while (($count = $this->cachePurge->getPurgeTagsCount()) > 0) {
+            if (!$force && $count < self::BATCH_SIZE) {
+                break;
             }
-		}
+            $limit = min($count, self::BATCH_SIZE);
+            $tags = $this->cachePurge->grabPurgeTags($limit);
+            $this->_shellPurge(['tags' => implode(',', $tags)]);
+        }
     }
 
 	private function _shellPurge($params)
@@ -156,7 +157,7 @@ class FlushCacheByCli implements \Magento\Framework\Event\ObserverInterface
 
             $server_ip = $this->config->getServerIp();
             $storeId = $this->config->getFrontStoreId();
-            $base = $this->url->getUrl('litemage/shell/purge', ['_scope' => $storeId, '_nosid' => true]);
+            $base = $this->url->getUrl('litemage/cli/purge', ['_scope' => $storeId, '_nosid' => true]);
             if ($server_ip) {
                 $pattern = "/:\/\/([^\/^:]+)(\/|:)?/";
                 if (preg_match($pattern, $base, $m)) {

--- a/Observer/FlushCacheByCli.php
+++ b/Observer/FlushCacheByCli.php
@@ -116,10 +116,10 @@ class FlushCacheByCli implements \Magento\Framework\Event\ObserverInterface
 			$data = curl_exec($ch);
 			if (!curl_errno($ch)) {
 				$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-				if ($http_code == 200) {
+				if ($http_code == 200 || $http_code == 201) {
 					$result = 'OK' . "\n$data";
 				} else {
-					$result = ' Unexpected HTTP code: ' . $http_code;
+					$result = ' Unexpected HTTP code: ' . $http_code . ' Body: ' . $data;
 					if ($http_code == 503) {
 						if (strpos($data, 'maintenance')) {
 							$result .= "\n*** Failed to send LiteMage flush request, please add your backend server IP to maintenance allowed ips.";
@@ -157,7 +157,11 @@ class FlushCacheByCli implements \Magento\Framework\Event\ObserverInterface
 
             $server_ip = $this->config->getServerIp();
             $storeId = $this->config->getFrontStoreId();
-            $base = $this->url->getUrl('litemage/cli/purge', ['_scope' => $storeId, '_nosid' => true]);
+            try {
+                $base = $this->url->getUrl('litemage/cli/purge', ['_scope' => $storeId, '_nosid' => true]);
+            } catch (\Exception $e) {
+                $base = $this->url->getUrl('litemage/cli/purge', ['_nosid' => true]);
+            }
             if ($server_ip) {
                 $pattern = "/:\/\/([^\/^:]+)(\/|:)?/";
                 if (preg_match($pattern, $base, $m)) {
@@ -190,9 +194,7 @@ class FlushCacheByCli implements \Magento\Framework\Event\ObserverInterface
             $options = $this->curl_options;
         }
         
-        $stat = stat(__FILE__);
-        $stat[] = date('l jS F Y h');
-        $params['secret'] = md5(print_r($stat, true));
+        $params['secret'] = md5(filemtime(__FILE__) . filesize(__FILE__) . gmdate('Y-m-d-H'));
         $base = $this->curl_options[CURLOPT_URL];
         
         //$uri = $base . 'litemage/shell/purge?' . http_build_query($params);


### PR DESCRIPTION
I fixed some issues with cli purge and purging after reindex.
I finally tested this on Magento 2.4.8, PHP 8.3 with and without Cloudflare protection (Cloudflare answers purge requests with 201 instead of 200).

I hope this will help somebody ;-)

cheers,
Martin